### PR TITLE
Export types for npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fhir-spec-tools",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Scripts and other shared tooling for working with the HL7® FHIR® standard",
   "main": "build/index.js",
   "files": [
@@ -8,7 +8,7 @@
     "build/index.js",
     "build/scripts/types/"
   ],
-  "types": "build/scripts/index.d.ts",
+  "types": "build/index.d.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/projecttacoma/fhir-spec-tools.git"

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build/index.js",
     "build/scripts/types/"
   ],
+  "types": "build/scripts/index.d.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/projecttacoma/fhir-spec-tools.git"

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,3 +7,4 @@ export * as PatientSearchParameters from './data/patient-search-parameters';
 export * as PrimaryDatePaths from './data/primaryDatePaths';
 export * as PropertyPaths from './data/propertyPaths';
 export * as SystemMap from './data/systemMap';
+export * from './scripts/types/types';


### PR DESCRIPTION
## Summary
Had trouble using the `fhir-spec-tools` as an npm package in `bulk-export-server` so this PR aims to fix that by hopefully properly exporting the types.

### New behavior
Hopefully can use package now.

### Code changes
- `src/index.ts` - specifically export types

## Testing guidance
- Question: when I publish this should I bump the version?
- `npm publish --dry-run` `types/index.js` and `types/index.d.ts` should be added.