### PR TITLE
Add parsing and data for code paths pulled from qicore

### DIFF
--- a/src/data/codePaths.ts
+++ b/src/data/codePaths.ts
@@ -1,6 +1,6 @@
 import { ResourceCodeInfo } from '../scripts/types/types';
 
-export const parsedCodePaths: Record<string, ResourceCodeInfo> = {
+export const FHIR401CodePaths: Record<string, ResourceCodeInfo> = {
   Account: {
     primaryCodePath: 'type',
     paths: {
@@ -3467,6 +3467,4435 @@ export const parsedCodePaths: Record<string, ResourceCodeInfo> = {
     paths: {
       status: {
         codeType: 'FHIR.code',
+        multipleCardinality: false,
+        choiceType: false
+      }
+    }
+  }
+};
+
+export const QICore411CodePaths: Record<string, ResourceCodeInfo> = {
+  AdverseEvent: {
+    primaryCodePath: 'event',
+    paths: {
+      category: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      event: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      seriousness: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      severity: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      outcome: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      }
+    }
+  },
+  AllergyIntolerance: {
+    primaryCodePath: 'code',
+    paths: {
+      reasonRefuted: {
+        codeType: 'QICore.reasonRefuted',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      clinicalStatus: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      verificationStatus: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      code: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      }
+    }
+  },
+  BodyStructure: {
+    primaryCodePath: 'location',
+    paths: {
+      morphology: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      location: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      locationQualifier: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      }
+    }
+  },
+  CarePlan: {
+    primaryCodePath: 'category',
+    paths: {
+      category: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      AssessPlan: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      }
+    }
+  },
+  CareTeam: {
+    primaryCodePath: 'category',
+    paths: {
+      category: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      reasonCode: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      }
+    }
+  },
+  Claim: {
+    primaryCodePath: 'type',
+    paths: {
+      type: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      subType: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      priority: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      fundsReserve: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      }
+    }
+  },
+  Communication: {
+    primaryCodePath: 'reasonCode',
+    paths: {
+      statusReason: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      category: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      medium: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      topic: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      reasonCode: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      }
+    }
+  },
+  CommunicationNotDone: {
+    primaryCodePath: 'reasonCode',
+    paths: {
+      statusReason: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      category: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      medium: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      topic: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      reasonCode: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: true
+      }
+    }
+  },
+  CommunicationRequest: {
+    primaryCodePath: 'category',
+    paths: {
+      statusReason: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      category: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      medium: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      reasonCode: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      }
+    }
+  },
+  Condition: {
+    primaryCodePath: 'code',
+    paths: {
+      clinicalStatus: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      verificationStatus: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      category: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      severity: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      code: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      bodySite: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      }
+    }
+  },
+  Coverage: {
+    primaryCodePath: 'type',
+    paths: {
+      type: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      relationship: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      }
+    }
+  },
+  Device: {
+    primaryCodePath: 'type',
+    paths: {
+      statusReason: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      type: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      safety: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      }
+    }
+  },
+  DeviceNotRequested: {
+    primaryCodePath: 'code',
+    paths: {
+      doNotPerformReason: {
+        codeType: 'QICore.DoNotPerformReason',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      code: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: true
+      },
+      performerType: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      reasonCode: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      }
+    }
+  },
+  DeviceRequest: {
+    primaryCodePath: 'code',
+    paths: {
+      code: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: true
+      },
+      performerType: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      reasonCode: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      }
+    }
+  },
+  DeviceUseStatement: {
+    primaryCodePath: 'device.type',
+    paths: {
+      reasonCode: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      bodySite: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      }
+    }
+  },
+  DiagnosticReportLab: {
+    primaryCodePath: 'code',
+    paths: {
+      category: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      LaboratorySlice: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      code: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      conclusionCode: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      }
+    }
+  },
+  DiagnosticReportNote: {
+    primaryCodePath: 'code',
+    paths: {
+      category: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      code: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      conclusionCode: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      }
+    }
+  },
+  Encounter: {
+    primaryCodePath: 'type',
+    paths: {
+      statusReason: {
+        codeType: 'QICore.statusReason',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      class: {
+        codeType: 'System.Code',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      type: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      serviceType: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      priority: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      reasonCode: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      }
+    }
+  },
+  FamilyMemberHistory: {
+    primaryCodePath: 'relationship',
+    paths: {
+      dataAbsentReason: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      relationship: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      sex: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      reasonCode: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      }
+    }
+  },
+  Flag: {
+    primaryCodePath: 'code',
+    paths: {
+      category: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      code: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      }
+    }
+  },
+  Goal: {
+    primaryCodePath: 'category',
+    paths: {
+      reasonRejected: {
+        codeType: 'QICore.reasonRejected',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      achievementStatus: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      category: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      priority: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      description: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      outcomeCode: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      }
+    }
+  },
+  ImagingStudy: {
+    primaryCodePath: 'procedureCode',
+    paths: {
+      modality: {
+        codeType: 'System.Code',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      procedureCode: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      reasonCode: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      }
+    }
+  },
+  Immunization: {
+    primaryCodePath: 'vaccineCode',
+    paths: {
+      statusReason: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      vaccineCode: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      reportOrigin: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      site: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      route: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      reasonCode: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      subpotentReason: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      programEligibility: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      fundingSource: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      }
+    }
+  },
+  ImmunizationEvaluation: {
+    primaryCodePath: 'targetDisease',
+    paths: {
+      targetDisease: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      doseStatus: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      doseStatusReason: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      }
+    }
+  },
+  ImmunizationNotDone: {
+    primaryCodePath: 'vaccineCode',
+    paths: {
+      statusReason: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      vaccineCode: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: true
+      },
+      reportOrigin: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      site: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      route: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      reasonCode: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      subpotentReason: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      programEligibility: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      fundingSource: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      }
+    }
+  },
+  ImmunizationRecommendation: {
+    primaryCodePath: 'recommendation.vaccineCode',
+    paths: {}
+  },
+  Location: {
+    primaryCodePath: 'type',
+    paths: {
+      operationalStatus: {
+        codeType: 'System.Code',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      type: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      physicalType: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      }
+    }
+  },
+  Medication: {
+    primaryCodePath: 'code',
+    paths: {
+      code: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      form: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      }
+    }
+  },
+  MedicationAdministration: {
+    primaryCodePath: 'medication',
+    paths: {
+      statusReason: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      category: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      medication: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: true
+      },
+      reasonCode: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      }
+    }
+  },
+  MedicationAdministrationNotDone: {
+    primaryCodePath: 'medication',
+    paths: {
+      statusReason: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      category: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      medication: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: true
+      },
+      reasonCode: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      }
+    }
+  },
+  MedicationDispense: {
+    primaryCodePath: 'medication',
+    paths: {
+      statusReason: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: true
+      },
+      category: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      medication: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: true
+      },
+      type: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      }
+    }
+  },
+  MedicationDispenseNotDone: {
+    primaryCodePath: 'medication',
+    paths: {
+      statusReason: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      category: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      medication: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: true
+      },
+      type: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      }
+    }
+  },
+  MedicationNotRequested: {
+    primaryCodePath: 'medication',
+    paths: {
+      statusReason: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      category: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      medication: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: true
+      },
+      performerType: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      reasonCode: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      courseOfTherapyType: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      }
+    }
+  },
+  MedicationRequest: {
+    primaryCodePath: 'medication',
+    paths: {
+      statusReason: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      category: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      medication: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: true
+      },
+      performerType: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      reasonCode: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      courseOfTherapyType: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      }
+    }
+  },
+  MedicationStatement: {
+    primaryCodePath: 'medication',
+    paths: {
+      statusReason: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      category: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      medication: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: true
+      },
+      reasonCode: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      }
+    }
+  },
+  Observation: {
+    primaryCodePath: 'code',
+    paths: {
+      bodyPosition: {
+        codeType: 'QICore.bodyPosition',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      delta: {
+        codeType: 'QICore.delta',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      category: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      code: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      value: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: true
+      },
+      dataAbsentReason: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      interpretation: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      bodySite: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      method: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      }
+    }
+  },
+  ObservationNotDone: {
+    primaryCodePath: 'code',
+    paths: {
+      notDoneReason: {
+        codeType: 'QICore.NotDoneReason',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      category: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      code: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: true
+      },
+      value: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: true
+      },
+      dataAbsentReason: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      interpretation: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      bodySite: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      method: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      }
+    }
+  },
+  Organization: {
+    primaryCodePath: 'type',
+    paths: {
+      type: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      }
+    }
+  },
+  Patient: {
+    paths: {
+      religion: {
+        codeType: 'QICore.religion',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      disability: {
+        codeType: 'QICore.disability',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      maritalStatus: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      }
+    }
+  },
+  Practitioner: {
+    paths: {
+      communication: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      }
+    }
+  },
+  PractitionerRole: {
+    primaryCodePath: 'code',
+    paths: {
+      code: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      specialty: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      }
+    }
+  },
+  Procedure: {
+    primaryCodePath: 'code',
+    paths: {
+      statusReason: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      category: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      code: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      reasonCode: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      bodySite: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      outcome: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      complication: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      followUp: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      usedCode: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      }
+    }
+  },
+  ProcedureNotDone: {
+    primaryCodePath: 'code',
+    paths: {
+      statusReason: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      category: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      code: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: true
+      },
+      reasonCode: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      bodySite: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      outcome: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      complication: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      followUp: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      usedCode: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      }
+    }
+  },
+  Questionnaire: {
+    primaryCodePath: 'name',
+    paths: {
+      jurisdiction: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      code: {
+        codeType: 'System.Code',
+        multipleCardinality: true,
+        choiceType: false
+      }
+    }
+  },
+  QuestionnaireResponse: {
+    paths: {}
+  },
+  RelatedPerson: {
+    primaryCodePath: 'relationship',
+    paths: {
+      relationship: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      }
+    }
+  },
+  ServiceNotRequested: {
+    primaryCodePath: 'code',
+    paths: {
+      reasonRefused: {
+        codeType: 'QICore.DoNotPerformReason',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      category: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      code: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: true
+      },
+      orderDetail: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      asNeeded: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: true
+      },
+      performerType: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      locationCode: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      reasonCode: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      bodySite: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      }
+    }
+  },
+  ServiceRequest: {
+    primaryCodePath: 'code',
+    paths: {
+      statusReason: {
+        codeType: 'QICore.statusReason',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      category: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      code: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      orderDetail: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      asNeeded: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: true
+      },
+      performerType: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      locationCode: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      reasonCode: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      bodySite: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      }
+    }
+  },
+  Specimen: {
+    primaryCodePath: 'type',
+    paths: {
+      type: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      condition: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      }
+    }
+  },
+  Substance: {
+    primaryCodePath: 'code',
+    paths: {
+      category: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      code: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      }
+    }
+  },
+  Task: {
+    primaryCodePath: 'code',
+    paths: {
+      statusReason: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      businessStatus: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      code: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      performerType: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      reasonCode: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      }
+    }
+  },
+  TaskNotDone: {
+    primaryCodePath: 'code',
+    paths: {
+      statusReason: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      businessStatus: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      code: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: true
+      },
+      performerType: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      reasonCode: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      }
+    }
+  },
+  USCoreImplantableDeviceProfile: {
+    primaryCodePath: 'type',
+    paths: {
+      statusReason: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      type: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      safety: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      }
+    }
+  },
+  USCoreLaboratoryResultObservationProfile: {
+    primaryCodePath: 'code',
+    paths: {
+      category: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      Laboratory: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      code: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      value: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: true
+      },
+      dataAbsentReason: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      interpretation: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      bodySite: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      method: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      }
+    }
+  },
+  USCorePediatricBMIforAgeObservationProfile: {
+    primaryCodePath: 'code',
+    paths: {
+      category: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      VSCat: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      code: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      dataAbsentReason: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      interpretation: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      bodySite: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      method: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      }
+    }
+  },
+  USCorePediatricWeightForHeightObservationProfile: {
+    primaryCodePath: 'code',
+    paths: {
+      category: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      VSCat: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      code: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      dataAbsentReason: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      interpretation: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      bodySite: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      method: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      }
+    }
+  },
+  USCorePulseOximetryProfile: {
+    primaryCodePath: 'code',
+    paths: {
+      category: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      VSCat: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      code: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      OxygenSatCode: {
+        codeType: 'System.Code',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      PulseOx: {
+        codeType: 'System.Code',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      dataAbsentReason: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      interpretation: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      bodySite: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      method: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      }
+    }
+  },
+  USCoreSmokingStatusProfile: {
+    primaryCodePath: 'code',
+    paths: {
+      category: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      code: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      value: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      dataAbsentReason: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      interpretation: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      bodySite: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      method: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      }
+    }
+  },
+  'observation-bmi': {
+    primaryCodePath: 'code',
+    paths: {
+      category: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      VSCat: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      code: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      BMICode: {
+        codeType: 'System.Code',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      dataAbsentReason: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      interpretation: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      bodySite: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      method: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      }
+    }
+  },
+  'observation-bodyheight': {
+    primaryCodePath: 'code',
+    paths: {
+      category: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      VSCat: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      code: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      BodyHeightCode: {
+        codeType: 'System.Code',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      dataAbsentReason: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      interpretation: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      bodySite: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      method: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      }
+    }
+  },
+  'observation-bodytemp': {
+    primaryCodePath: 'code',
+    paths: {
+      category: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      VSCat: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      code: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      BodyTempCode: {
+        codeType: 'System.Code',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      dataAbsentReason: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      interpretation: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      bodySite: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      method: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      }
+    }
+  },
+  'observation-bodyweight': {
+    primaryCodePath: 'code',
+    paths: {
+      category: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      VSCat: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      code: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      BodyWeightCode: {
+        codeType: 'System.Code',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      dataAbsentReason: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      interpretation: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      bodySite: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      method: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      }
+    }
+  },
+  'observation-bp': {
+    primaryCodePath: 'code',
+    paths: {
+      category: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      VSCat: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      code: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      BPCode: {
+        codeType: 'System.Code',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      dataAbsentReason: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      interpretation: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      bodySite: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      method: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      }
+    }
+  },
+  'observation-headcircum': {
+    primaryCodePath: 'code',
+    paths: {
+      category: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      VSCat: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      code: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      HeadCircumCode: {
+        codeType: 'System.Code',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      dataAbsentReason: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      interpretation: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      bodySite: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      method: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      }
+    }
+  },
+  'observation-heartrate': {
+    primaryCodePath: 'code',
+    paths: {
+      category: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      VSCat: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      code: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      HeartRateCode: {
+        codeType: 'System.Code',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      dataAbsentReason: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      interpretation: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      bodySite: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      method: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      }
+    }
+  },
+  'observation-oxygensat': {
+    primaryCodePath: 'code',
+    paths: {
+      category: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      VSCat: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      code: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      OxygenSatCode: {
+        codeType: 'System.Code',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      dataAbsentReason: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      interpretation: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      bodySite: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      method: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      }
+    }
+  },
+  'observation-resprate': {
+    primaryCodePath: 'code',
+    paths: {
+      category: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      VSCat: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      code: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      RespRateCode: {
+        codeType: 'System.Code',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      dataAbsentReason: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      interpretation: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      bodySite: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      method: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      }
+    }
+  },
+  'observation-vitalspanel': {
+    primaryCodePath: 'code',
+    paths: {
+      category: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      VSCat: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      code: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      VitalsPanelCode: {
+        codeType: 'System.Code',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      dataAbsentReason: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      interpretation: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      bodySite: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      method: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      }
+    }
+  }
+};
+
+export const QICore600CodePaths: Record<string, ResourceCodeInfo> = {
+  AdverseEvent: {
+    primaryCodePath: 'event',
+    paths: {
+      category: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      event: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      seriousness: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      severity: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      outcome: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      }
+    }
+  },
+  AllergyIntolerance: {
+    primaryCodePath: 'code',
+    paths: {
+      clinicalStatus: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      verificationStatus: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      code: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      }
+    }
+  },
+  BodyStructure: {
+    primaryCodePath: 'location',
+    paths: {
+      morphology: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      location: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      locationQualifier: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      }
+    }
+  },
+  CarePlan: {
+    primaryCodePath: 'category',
+    paths: {
+      category: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      AssessPlan: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      }
+    }
+  },
+  CareTeam: {
+    primaryCodePath: 'category',
+    paths: {
+      category: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      reasonCode: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      }
+    }
+  },
+  Claim: {
+    primaryCodePath: 'type',
+    paths: {
+      type: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      subType: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      priority: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      fundsReserve: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      }
+    }
+  },
+  ClaimResponse: {
+    paths: {
+      type: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      subType: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      payeeType: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      fundsReserve: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      formCode: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      }
+    }
+  },
+  Communication: {
+    primaryCodePath: 'topic',
+    paths: {
+      statusReason: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      category: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      medium: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      topic: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      reasonCode: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      }
+    }
+  },
+  CommunicationNotDone: {
+    primaryCodePath: 'topic',
+    paths: {
+      statusReason: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      category: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      medium: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      topic: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: true
+      },
+      reasonCode: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      }
+    }
+  },
+  CommunicationRequest: {
+    primaryCodePath: 'category',
+    paths: {
+      statusReason: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      category: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      medium: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      reasonCode: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      }
+    }
+  },
+  ConditionEncounterDiagnosis: {
+    primaryCodePath: 'code',
+    paths: {
+      clinicalStatus: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      verificationStatus: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      category: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      'us-core': {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      severity: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      code: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      bodySite: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      }
+    }
+  },
+  ConditionProblemsHealthConcerns: {
+    primaryCodePath: 'code',
+    paths: {
+      clinicalStatus: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      verificationStatus: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      category: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      'us-core': {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      'screening-assessment': {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      severity: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      code: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      bodySite: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      }
+    }
+  },
+  Coverage: {
+    primaryCodePath: 'type',
+    paths: {
+      type: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      relationship: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      }
+    }
+  },
+  Device: {
+    primaryCodePath: 'type',
+    paths: {
+      statusReason: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      type: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      safety: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      }
+    }
+  },
+  DeviceNotRequested: {
+    primaryCodePath: 'code',
+    paths: {
+      doNotPerformReason: {
+        codeType: 'QICore.DoNotPerformReason',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      code: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: true
+      },
+      performerType: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      reasonCode: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      }
+    }
+  },
+  DeviceRequest: {
+    primaryCodePath: 'code',
+    paths: {
+      code: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: true
+      },
+      performerType: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      reasonCode: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      }
+    }
+  },
+  DeviceUseStatement: {
+    primaryCodePath: 'device.type',
+    paths: {
+      reasonCode: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      bodySite: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      }
+    }
+  },
+  DiagnosticReportLab: {
+    primaryCodePath: 'code',
+    paths: {
+      category: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      LaboratorySlice: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      code: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      conclusionCode: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      }
+    }
+  },
+  DiagnosticReportNote: {
+    primaryCodePath: 'code',
+    paths: {
+      category: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      'us-core': {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      code: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      conclusionCode: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      }
+    }
+  },
+  Encounter: {
+    primaryCodePath: 'type',
+    paths: {
+      class: {
+        codeType: 'System.Code',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      type: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      serviceType: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      priority: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      reasonCode: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      }
+    }
+  },
+  FamilyMemberHistory: {
+    primaryCodePath: 'relationship',
+    paths: {
+      dataAbsentReason: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      relationship: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      sex: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      reasonCode: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      }
+    }
+  },
+  Flag: {
+    primaryCodePath: 'code',
+    paths: {
+      category: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      code: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      }
+    }
+  },
+  Goal: {
+    primaryCodePath: 'category',
+    paths: {
+      achievementStatus: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      category: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      priority: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      description: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      start: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: true
+      },
+      outcomeCode: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      }
+    }
+  },
+  ImagingStudy: {
+    primaryCodePath: 'procedureCode',
+    paths: {
+      modality: {
+        codeType: 'System.Code',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      procedureCode: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      reasonCode: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      }
+    }
+  },
+  Immunization: {
+    primaryCodePath: 'vaccineCode',
+    paths: {
+      statusReason: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      vaccineCode: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      reportOrigin: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      site: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      route: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      reasonCode: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      subpotentReason: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      programEligibility: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      fundingSource: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      }
+    }
+  },
+  ImmunizationEvaluation: {
+    primaryCodePath: 'targetDisease',
+    paths: {
+      targetDisease: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      doseStatus: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      doseStatusReason: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      }
+    }
+  },
+  ImmunizationNotDone: {
+    primaryCodePath: 'vaccineCode',
+    paths: {
+      statusReason: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      vaccineCode: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: true
+      },
+      reportOrigin: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      site: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      route: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      reasonCode: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      subpotentReason: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      programEligibility: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      fundingSource: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      }
+    }
+  },
+  ImmunizationRecommendation: {
+    primaryCodePath: 'recommendation.vaccineCode',
+    paths: {}
+  },
+  LaboratoryResultObservation: {
+    primaryCodePath: 'code',
+    paths: {
+      category: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      'us-core': {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      code: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      value: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: true
+      },
+      dataAbsentReason: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      interpretation: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      bodySite: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      method: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      }
+    }
+  },
+  Location: {
+    primaryCodePath: 'type',
+    paths: {
+      operationalStatus: {
+        codeType: 'System.Code',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      type: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      physicalType: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      }
+    }
+  },
+  Medication: {
+    primaryCodePath: 'code',
+    paths: {
+      code: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      form: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      }
+    }
+  },
+  MedicationAdministration: {
+    primaryCodePath: 'medication',
+    paths: {
+      statusReason: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      category: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      medication: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: true
+      },
+      reasonCode: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      }
+    }
+  },
+  MedicationAdministrationNotDone: {
+    primaryCodePath: 'medication',
+    paths: {
+      statusReason: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      category: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      medication: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: true
+      },
+      reasonCode: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      }
+    }
+  },
+  MedicationDispense: {
+    primaryCodePath: 'medication',
+    paths: {
+      statusReason: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: true
+      },
+      category: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      medication: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: true
+      },
+      type: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      }
+    }
+  },
+  MedicationDispenseDeclined: {
+    primaryCodePath: 'medication',
+    paths: {
+      statusReason: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      category: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      medication: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: true
+      },
+      type: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      }
+    }
+  },
+  MedicationNotRequested: {
+    primaryCodePath: 'medication',
+    paths: {
+      statusReason: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      category: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      'us-core': {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      medication: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: true
+      },
+      performerType: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      reasonCode: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      courseOfTherapyType: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      }
+    }
+  },
+  MedicationRequest: {
+    primaryCodePath: 'medication',
+    paths: {
+      statusReason: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      category: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      'us-core': {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      medication: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: true
+      },
+      performerType: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      reasonCode: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      courseOfTherapyType: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      }
+    }
+  },
+  MedicationStatement: {
+    primaryCodePath: 'medication',
+    paths: {
+      statusReason: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      category: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      medication: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: true
+      },
+      reasonCode: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      }
+    }
+  },
+  NonPatientObservation: {
+    primaryCodePath: 'code',
+    paths: {
+      category: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      code: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      value: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      dataAbsentReason: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      interpretation: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      bodySite: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      method: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      }
+    }
+  },
+  NutritionOrder: {
+    paths: {
+      foodPreferenceModifier: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      excludeFoodModifier: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      }
+    }
+  },
+  ObservationCancelled: {
+    primaryCodePath: 'code',
+    paths: {
+      notDoneReason: {
+        codeType: 'QICore.NotDoneReason',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      category: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      code: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: true
+      },
+      value: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      dataAbsentReason: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      interpretation: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      bodySite: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      method: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      }
+    }
+  },
+  ObservationClinicalResult: {
+    primaryCodePath: 'code',
+    paths: {
+      category: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      'us-core': {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      code: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      value: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: true
+      },
+      dataAbsentReason: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      interpretation: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      bodySite: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      method: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      }
+    }
+  },
+  ObservationScreeningAssessment: {
+    primaryCodePath: 'code',
+    paths: {
+      category: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      survey: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      'screening-assessment': {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      code: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      value: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: true
+      },
+      dataAbsentReason: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      interpretation: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      bodySite: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      method: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      }
+    }
+  },
+  Organization: {
+    primaryCodePath: 'type',
+    paths: {
+      type: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      }
+    }
+  },
+  Patient: {
+    paths: {
+      genderIdentity: {
+        codeType: 'QICore.USCoreGenderIdentityExtension',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      maritalStatus: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      }
+    }
+  },
+  Practitioner: {
+    paths: {
+      communication: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      }
+    }
+  },
+  PractitionerRole: {
+    primaryCodePath: 'code',
+    paths: {
+      code: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      specialty: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      }
+    }
+  },
+  Procedure: {
+    primaryCodePath: 'code',
+    paths: {
+      statusReason: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      category: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      code: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      reasonCode: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      bodySite: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      outcome: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      complication: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      followUp: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      usedCode: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      }
+    }
+  },
+  ProcedureNotDone: {
+    primaryCodePath: 'code',
+    paths: {
+      statusReason: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      category: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      code: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: true
+      },
+      reasonCode: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      bodySite: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      outcome: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      complication: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      followUp: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      usedCode: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      }
+    }
+  },
+  Questionnaire: {
+    primaryCodePath: 'name',
+    paths: {
+      jurisdiction: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      code: {
+        codeType: 'System.Code',
+        multipleCardinality: true,
+        choiceType: false
+      }
+    }
+  },
+  QuestionnaireResponse: {
+    paths: {
+      completionMode: {
+        codeType: 'QICore.completionMode',
+        multipleCardinality: false,
+        choiceType: false
+      }
+    }
+  },
+  RelatedPerson: {
+    primaryCodePath: 'relationship',
+    paths: {
+      relationship: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      }
+    }
+  },
+  ServiceNotRequested: {
+    primaryCodePath: 'code',
+    paths: {
+      reasonRefused: {
+        codeType: 'QICore.DoNotPerformReason',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      category: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      'us-core': {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      code: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: true
+      },
+      orderDetail: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      asNeeded: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: true
+      },
+      performerType: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      locationCode: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      reasonCode: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      bodySite: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      }
+    }
+  },
+  ServiceRequest: {
+    primaryCodePath: 'code',
+    paths: {
+      category: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      'us-core': {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      code: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      orderDetail: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      asNeeded: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: true
+      },
+      performerType: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      locationCode: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      reasonCode: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      bodySite: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      }
+    }
+  },
+  SimpleObservation: {
+    primaryCodePath: 'code',
+    paths: {
+      category: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      'us-core': {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      code: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      value: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: true
+      },
+      dataAbsentReason: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      interpretation: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      bodySite: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      method: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      }
+    }
+  },
+  Substance: {
+    primaryCodePath: 'code',
+    paths: {
+      category: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      code: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      }
+    }
+  },
+  Task: {
+    primaryCodePath: 'code',
+    paths: {
+      statusReason: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      businessStatus: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      code: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      performerType: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      reasonCode: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      }
+    }
+  },
+  TaskRejected: {
+    primaryCodePath: 'code',
+    paths: {
+      statusReason: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      businessStatus: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      code: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: true
+      },
+      performerType: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      reasonCode: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      }
+    }
+  },
+  USCoreBMIProfile: {
+    primaryCodePath: 'code',
+    paths: {
+      category: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      VSCat: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      code: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      dataAbsentReason: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      interpretation: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      bodySite: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      method: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      }
+    }
+  },
+  USCoreBloodPressureProfile: {
+    primaryCodePath: 'code',
+    paths: {
+      category: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      VSCat: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      code: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      value: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: true
+      },
+      dataAbsentReason: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      interpretation: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      bodySite: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      method: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      }
+    }
+  },
+  USCoreBodyHeightProfile: {
+    primaryCodePath: 'code',
+    paths: {
+      category: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      VSCat: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      code: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      dataAbsentReason: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      interpretation: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      bodySite: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      method: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      }
+    }
+  },
+  USCoreBodyTemperatureProfile: {
+    primaryCodePath: 'code',
+    paths: {
+      category: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      VSCat: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      code: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      dataAbsentReason: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      interpretation: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      bodySite: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      method: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      }
+    }
+  },
+  USCoreBodyWeightProfile: {
+    primaryCodePath: 'code',
+    paths: {
+      category: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      VSCat: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      code: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      dataAbsentReason: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      interpretation: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      bodySite: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      method: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      }
+    }
+  },
+  USCoreHeadCircumferenceProfile: {
+    primaryCodePath: 'code',
+    paths: {
+      category: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      VSCat: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      code: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      dataAbsentReason: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      interpretation: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      bodySite: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      method: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      }
+    }
+  },
+  USCoreHeartRateProfile: {
+    primaryCodePath: 'code',
+    paths: {
+      category: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      VSCat: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      code: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      dataAbsentReason: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      interpretation: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      bodySite: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      method: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      }
+    }
+  },
+  USCoreImplantableDeviceProfile: {
+    primaryCodePath: 'type',
+    paths: {
+      statusReason: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      type: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      safety: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      }
+    }
+  },
+  USCoreObservationOccupationProfile: {
+    primaryCodePath: 'code',
+    paths: {
+      category: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      socialhistory: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      code: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      value: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      dataAbsentReason: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      interpretation: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      bodySite: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      method: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      }
+    }
+  },
+  USCoreObservationPregnancyIntentProfile: {
+    primaryCodePath: 'code',
+    paths: {
+      category: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      SocialHistory: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      code: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      value: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      dataAbsentReason: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      interpretation: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      bodySite: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      method: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      }
+    }
+  },
+  USCoreObservationPregnancyStatusProfile: {
+    primaryCodePath: 'code',
+    paths: {
+      category: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      SocialHistory: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      code: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      value: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      dataAbsentReason: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      interpretation: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      bodySite: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      method: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      }
+    }
+  },
+  USCoreObservationSexualOrientationProfile: {
+    primaryCodePath: 'code',
+    paths: {
+      category: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      code: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      value: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      dataAbsentReason: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      interpretation: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      bodySite: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      method: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      }
+    }
+  },
+  USCorePediatricBMIforAgeObservationProfile: {
+    primaryCodePath: 'code',
+    paths: {
+      category: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      VSCat: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      code: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      dataAbsentReason: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      interpretation: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      bodySite: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      method: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      }
+    }
+  },
+  USCorePediatricHeadOccipitalFrontalCircumferencePercentileProfile: {
+    primaryCodePath: 'code',
+    paths: {
+      category: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      VSCat: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      code: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      dataAbsentReason: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      interpretation: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      bodySite: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      method: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      }
+    }
+  },
+  USCorePediatricWeightForHeightObservationProfile: {
+    primaryCodePath: 'code',
+    paths: {
+      category: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      VSCat: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      code: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      dataAbsentReason: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      interpretation: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      bodySite: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      method: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      }
+    }
+  },
+  USCorePulseOximetryProfile: {
+    primaryCodePath: 'code',
+    paths: {
+      category: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      VSCat: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      code: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      PulseOx: {
+        codeType: 'System.Code',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      O2Sat: {
+        codeType: 'System.Code',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      dataAbsentReason: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      interpretation: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      bodySite: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      method: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      }
+    }
+  },
+  USCoreRespiratoryRateProfile: {
+    primaryCodePath: 'code',
+    paths: {
+      category: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      VSCat: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      code: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      dataAbsentReason: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      interpretation: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      bodySite: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      method: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      }
+    }
+  },
+  USCoreSmokingStatusProfile: {
+    primaryCodePath: 'code',
+    paths: {
+      category: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      SocialHistory: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      code: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      value: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: true
+      },
+      dataAbsentReason: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      interpretation: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      bodySite: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      method: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      }
+    }
+  },
+  USCoreSpecimenProfile: {
+    paths: {
+      type: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      condition: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      }
+    }
+  },
+  USCoreVitalSignsProfile: {
+    primaryCodePath: 'code',
+    paths: {
+      category: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      VSCat: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      code: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      value: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: true
+      },
+      dataAbsentReason: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      interpretation: {
+        codeType: 'System.Concept',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      bodySite: {
+        codeType: 'System.Concept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      method: {
+        codeType: 'System.Concept',
         multipleCardinality: false,
         choiceType: false
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,4 @@
 export * as ChoiceTypes from './data/choiceTypes';
-export * as CodePaths from './data/codePaths';
 export * as DateSearchParameters from './data/dateSearchParameters';
 export * as ExpressionSearchParameters from './data/expressionSearchParameters';
 export * as MandatoryElements from './data/mandatoryElements';
@@ -8,5 +7,6 @@ export * as PatientSearchParameters from './data/patient-search-parameters';
 export * as PrimaryDatePaths from './data/primaryDatePaths';
 export * as PropertyPaths from './data/propertyPaths';
 export * as SystemMap from './data/systemMap';
+export * from './data/codePaths';
 export * from './data/primary-code-paths';
 export * from './scripts/types/types';

--- a/src/scripts/parseCodePath.ts
+++ b/src/scripts/parseCodePath.ts
@@ -4,9 +4,8 @@ import * as path from 'path';
 import * as xml2js from 'xml2js';
 import { ResourceCodeInfo, CodePathInfo } from './types/types';
 
-const modelInfoPath = path.resolve(path.join(__dirname, '../fhir/fhir-modelinfo-4.0.1.xml'));
+const specFolderPath = path.resolve(path.join(__dirname, '../fhir'));
 const outputPath = path.resolve(path.join(__dirname, '../data/codePaths.ts'));
-const xmlStr = fs.readFileSync(modelInfoPath, 'utf8');
 
 interface ElementChoice {
   $: {
@@ -21,7 +20,7 @@ interface ElementChoice {
  * for each FHIR Resource type.
  * @param {string} xml the string content of the model info XML to parse
  * @return object whose keys are resourceTypes and values correspond to
- * the resourceTypes' primaryCodePath
+ * the resourceTypes' primaryCodePath and code path information
  */
 export async function parse(xml: string) {
   const { modelInfo } = await xml2js.parseStringPromise(xml);
@@ -36,23 +35,19 @@ export async function parse(xml: string) {
     const primaryCodePath = di.$.primaryCodePath;
     const paths: Record<string, CodePathInfo> = {};
 
-    let codeType: string;
-    let multipleCardinality: boolean;
-    let choiceType: boolean;
-
     // go through every element in the domainInfo
     di.element.forEach((elem: any) => {
+      // defaults
+      let codeType = '';
+      let multipleCardinality = false;
+      let choiceType = false;
       if (elem.elementTypeSpecifier) {
         // length of element.elementTypeSpecifier is always 1, so we can index it at 0
         if (elem.elementTypeSpecifier[0].choice) {
           // xsi:type is ChoiceTypeSpecifier, so there are multiple possible types
-          // save both options to an array
-          const choices: string[] = [];
-          elem.elementTypeSpecifier[0].choice.forEach((c: ElementChoice) => {
-            const choiceNamespace = c.$.namespace;
-            const choiceName = c.$.name;
-            choices.push(`${choiceNamespace}.${choiceName}`);
-          });
+          const choices: string[] = elem.elementTypeSpecifier[0].choice.map(
+            (c: ElementChoice) => `${c.$.namespace}.${c.$.name}`
+          );
 
           // apply heuristic for selecting
           if (choices.includes('FHIR.CodeableConcept')) {
@@ -63,10 +58,7 @@ export async function parse(xml: string) {
             codeType = 'FHIR.code';
           }
 
-          // all choice types are 0..1 or 1..1 cardinality
-          multipleCardinality = false;
-
-          // indicate that this is a choice type
+          // indicate that this is a choice type (all choice types are 0..1 or 1..1 cardinality)
           choiceType = true;
         } else {
           // xsi:type is ListTypeSpecifier
@@ -74,22 +66,14 @@ export async function parse(xml: string) {
 
           // single type of 0..* or 1..* cardinality
           multipleCardinality = true;
-
-          // indicate that this is not a choice type
-          choiceType = false;
         }
       } else {
         // single type of 0..1 or 1..1 cardinality
         codeType = elem.$.elementType;
-        multipleCardinality = false;
-
-        // indicate that this is not a choice type
-        choiceType = false;
       }
       // add elements of these three types to the paths of that resource
       if (codeType === 'FHIR.CodeableConcept' || codeType === 'FHIR.Coding' || codeType === 'FHIR.code') {
         paths[elem.$.name] = { codeType, multipleCardinality, choiceType };
-        codeType = '';
       } else if (codeType && codeType !== 'FHIR.string') {
         // if the codeType is not one of those three but also not a FHIR.string it may be within a FHIR.Element
         const codeTypeName = codeType.split('R.');
@@ -102,7 +86,6 @@ export async function parse(xml: string) {
               multipleCardinality,
               choiceType
             };
-            codeType = '';
           }
         }
       }
@@ -115,20 +98,102 @@ export async function parse(xml: string) {
   return results;
 }
 
-parse(xmlStr)
-  .then(data => {
-    fs.writeFileSync(
-      outputPath,
-      `
-        import { ResourceCodeInfo } from '../scripts/types/types';
+/**
+ * Parse QICore Model Info XML and output codePath information
+ * for each Domain Resource type.
+ * @param {string} xml the string content of the model info XML to parse
+ * @return object whose keys are resourceTypes and values correspond to
+ * the resourceTypes' primaryCodePath and code path information
+ */
+export async function parseQICore(xml: string) {
+  const { modelInfo } = await xml2js.parseStringPromise(xml);
+  const domainInfo = modelInfo.typeInfo.filter((ti: any) => ti.$.baseType === 'QICore.DomainResource');
 
-        export const parsedCodePaths: Record<string, ResourceCodeInfo> =
-          ${JSON.stringify(data, null, 2)};
-        `,
-      'utf8'
-    );
-    console.log(`Wrote file to ${outputPath}`);
-  })
-  .catch(e => {
-    console.error(e);
+  // QICore types where the base is System.Concept (no System.Code bases exist)
+  const baseConcepts: string[] = modelInfo.typeInfo
+    .filter((ti: any) => ti.$.baseType === 'System.Concept')
+    .map((ti: any) => `${ti.$.namespace}.${ti.$.name}`);
+
+  const results: { [key: string]: ResourceCodeInfo } = {};
+
+  domainInfo.forEach((di: any) => {
+    const resourceType = di.$.name;
+    const primaryCodePath = di.$.primaryCodePath;
+    const paths: Record<string, CodePathInfo> = {};
+
+    // go through every element in the domainInfo
+    di.element.forEach((elem: any) => {
+      // defaults
+      let codeType = '';
+      let multipleCardinality = false;
+      let choiceType = false;
+
+      if (elem.elementTypeSpecifier) {
+        // length of element.elementTypeSpecifier is always 1, so we can index it at 0
+        if (elem.elementTypeSpecifier[0].choice) {
+          // xsi:type is ChoiceTypeSpecifier, so there are multiple possible types
+          const choices: string[] = elem.elementTypeSpecifier[0].choice.map(
+            (c: ElementChoice) => `${c.$.namespace}.${c.$.name}`
+          );
+
+          // select System.Concept over System.Code
+          if (choices.includes('System.Concept')) {
+            codeType = 'System.Concept';
+          } else if (choices.includes('System.Code')) {
+            codeType = 'System.Code';
+          }
+
+          // indicate that this is a choice type (all choice types are 0..1 or 1..1 cardinality)
+          choiceType = true;
+        } else {
+          // xsi:type is ListTypeSpecifier
+          codeType = elem.elementTypeSpecifier[0].$.elementType;
+
+          // single type of 0..* or 1..* cardinality
+          multipleCardinality = true;
+        }
+      } else {
+        // single type of 0..1 or 1..1 cardinality
+        codeType = elem.$.elementType;
+      }
+
+      // add elements of these types to the paths
+      if (codeType === 'System.Concept' || codeType === 'System.Code' || baseConcepts.includes(codeType)) {
+        // Note: this keeps the QICore specified type rather than simplifying to the base System.Concept
+        paths[elem.$.name] = { codeType, multipleCardinality, choiceType };
+      }
+    });
+
+    results[resourceType] = {
+      primaryCodePath: primaryCodePath,
+      paths: paths
+    };
   });
+  return results;
+}
+
+/**
+ * Scan src/fhir for FHIR and QICore modelinfo files and generate a TS file with exported objects for each
+ * FHIR and QICore model, where the object is a map of resourceType => ResourceCodeInfo. Assumes modelinfo
+ * file names with format: [qicore|fhir}-modelinfo-X.Y.Z.xml, where X, Y, and Z are major, minor, and patch
+ * components of version. Exported objects have corresponding name: [QICore|FHIR]XYZCodePaths.
+ * Example: qicore-modelinfo-4.1.1.xml results in exported variable QICore411CodePaths.
+ */
+async function main() {
+  const exports: string[] = [`import { ResourceCodeInfo } from '../scripts/types/types';`];
+  for (const file of fs.readdirSync(specFolderPath)) {
+    const match = file.match(/^(qicore|fhir)-modelinfo-(\d+)\.(\d+)\.(\d+)\.xml$/);
+    if (match) {
+      const isQICore = file.startsWith('qicore');
+      const name = `${isQICore ? 'QICore' : 'FHIR'}${match[2]}${match[3]}${match[4]}CodePaths`;
+      const xml = fs.readFileSync(path.resolve(specFolderPath, file), 'utf8');
+      const data = isQICore ? await parseQICore(xml) : await parse(xml);
+      exports.push(`export const ${name}: Record<string, ResourceCodeInfo> = ${JSON.stringify(data, null, 2)};`);
+    }
+  }
+
+  fs.writeFileSync(outputPath, exports.join('\n\n'), 'utf8');
+  console.log(`Wrote file to ${outputPath}`);
+}
+
+main();


### PR DESCRIPTION
# Summary
Update codePaths to also include code-based paths for resources pulled from the qicore modelinfo files

## New behavior
Running `npm run build:codes` creates two additional objects in the `codePaths.ts` data file (and the previous object has a new spec-specific name).

## Code changes
- `parseCodePaths.ts`, changes the main function to parse all available fhir or qicore model infos, creates a new parsing function for the qicore model info, and updates the fhir parsing function to simplify the code (hopefully a little shorter and more readable)
- `codePaths.ts` generated new codePaths for new qicore codepath objects

# Testing guidance
- `npm run check`
- `npm run build:codes` (should be no changes except name on the fhir object, and should add two qicore objects)
- Check for code-like objects of interest. For instance, the ticket references ServiceNotRequested reasonRefused. (You could also test by linking with `fqm-testify`?, but we don't currently have a branch that does anything with this information.)
- Inspect the output object to make sure that the objects make sense. Some of the 4.1.1 domain resources are interesting... for instance, see "observation-vitalspanel" which seems to be an Observation with a slicing that has a Vitals Panel coding. Do we want the information for those in a different format? I suspect we won't use those weird ones at all though, so it probably doesn't matter.
